### PR TITLE
Fix for clicking on a Completed form under Completed Forms tab causes ap...

### DIFF
--- a/src/main/java/com/muzima/view/forms/HTMLFormWebViewActivity.java
+++ b/src/main/java/com/muzima/view/forms/HTMLFormWebViewActivity.java
@@ -425,8 +425,8 @@ public class HTMLFormWebViewActivity extends BroadcastListenerActivity {
     }
 
     private boolean isEncounterForm() {
-        return getIntent().getStringExtra(DISCRIMINATOR).equals(Constants.FORM_JSON_DISCRIMINATOR_ENCOUNTER)
-                || getIntent().getStringExtra(DISCRIMINATOR).equals(Constants.FORM_JSON_DISCRIMINATOR_CONSULTATION);
+        return formData.getDiscriminator().equalsIgnoreCase(Constants.FORM_JSON_DISCRIMINATOR_ENCOUNTER)
+                || formData.getDiscriminator().equalsIgnoreCase(Constants.FORM_JSON_DISCRIMINATOR_CONSULTATION);
     }
 }
 


### PR DESCRIPTION
...p crash.

Hi @nribeka,

This is a fix for an issue that I am seeing on the Completed Forms tab (under Clients and Forms sections). The issue is that when a user clicks on a completed form to view it, a null pointer exception occurs and subsequently the app crashes.
This is a quick fix that I have provided, please let me know if you are okay with this fix.
