### PR TITLE
MUZIMA-200 : Option to allow users to send stacktrace to listserv

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.GET_TASKS"/>
+    <uses-permission android:name="android.permission.READ_LOGS" />
 
     <application
             android:allowBackup="true"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -299,5 +299,6 @@
     <string name="preference_encounter_provider_desc">Logged-in user as default encounter form provider</string>
     <string name="preference_encounter_provider_title">Default encounter provider</string>
     <string name="preference_encounter_provider">encounterProviderPreference</string>
+    <string name="crash_toast_text">\"Sorry, mUzima has crashed. A crash report will be sent to the team.\"</string>
 
 </resources>

--- a/src/main/java/com/muzima/MuzimaApplication.java
+++ b/src/main/java/com/muzima/MuzimaApplication.java
@@ -56,12 +56,13 @@ import static com.muzima.view.preferences.MuzimaTimer.getTimer;
 
 @ReportsCrashes(
         formKey = "",
-        formUri = "http://prasann.cloudant.com/acra-muzima/_design/acra-storage/_update/report",
+        formUri = "https://muzima.cloudant.com/acra-muzima/_design/acra-storage/_update/report",
         reportType = HttpSender.Type.JSON,
-        httpMethod = HttpSender.Method.PUT,
-        formUriBasicAuthLogin = "utionermsedeastagesinibl",
-        formUriBasicAuthPassword = "QJi5kBCe36wGC6jeMeWfSB4q",
-        mode = ReportingInteractionMode.TOAST)
+        httpMethod = HttpSender.Method.POST,
+        formUriBasicAuthLogin = "pontonlympservilifleyeto",
+        formUriBasicAuthPassword = "OMHKOHV8LVfv3c553n6Oqkof",
+        mode = ReportingInteractionMode.TOAST,
+        resToastText = R.string.crash_toast_text)
 public class MuzimaApplication extends Application {
     private Context muzimaContext;
     private Activity currentActivity;


### PR DESCRIPTION
ACRA + Cloudant integration for mUzima, with these changes error logs are sent to ACRA(reports are stored on Cloudant https://muzima.cloudant.com/dashboard.html#). The dashboard view can be seen at Acralyzer http://muzima.cloudant.com/acralyzer/_design/acralyzer/index.html#/dashboard/muzima
