### PR TITLE
MUZIMA-281: Enable serializing and populating obs_datetime alongside obs value

### DIFF
--- a/assets/www/forms/css/muzima.css
+++ b/assets/www/forms/css/muzima.css
@@ -1,4 +1,4 @@
-.section {
+.section, .sub-section {
     padding: 10px;
     border: 1px solid #000000;
     border-radius: 5px;


### PR DESCRIPTION
This change will enable observations to serialize observation value and datetime in the format
concept_id:{"obs_value":value, "obs_datetime":datetime} for observations with obs_datetime field, and retains concept_id:value for observations with no obs_datetime.