### PR TITLE
MUZIMA-666: Reposition cursor on session timeout

### DIFF
--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -49,7 +49,8 @@
                 android:negativeButtonText="@android:string/cancel"
                 android:positiveButtonText="@android:string/ok"
                 android:title="@string/title_session_timeout"
-                android:inputType="number"/>
+                android:inputType="number"
+                android:selectAllOnFocus="true"/>
         <EditTextPreference
                 android:defaultValue="@string/default_auto_save_interval"
                 android:dialogMessage="@string/hint_form_auto_save_interval"


### PR DESCRIPTION
I set the 'SelectAllOnFocus' property for session timeout Edittext to true. It selects all the text when the focus is on the text. (And the user can rewrite the whole value easier.)