### PR TITLE
MUZIMA-653: validation of session timeout and update warning text

### DIFF
--- a/app/src/main/java/com/muzima/view/preferences/settings/SettingsPreferenceFragment.java
+++ b/app/src/main/java/com/muzima/view/preferences/settings/SettingsPreferenceFragment.java
@@ -120,13 +120,15 @@ public class SettingsPreferenceFragment extends PreferenceFragment  implements S
             }
 
             private Integer extractSessionTimoutValue(Object o) {
-                if (o != null && !o.toString().isEmpty()) {
+                try {
                     Integer timeOutInMin = Integer.valueOf(o.toString());
-                    if (timeOutInMin > SESSION_TIMEOUT_MINIMUM && timeOutInMin < SESSION_TIMEOUT_MAXIMUM) {
+                    if (timeOutInMin > SESSION_TIMEOUT_MINIMUM && timeOutInMin <= SESSION_TIMEOUT_MAXIMUM) {
                         return timeOutInMin;
                     }
+                    return SESSION_TIMEOUT_INVALID_VALUE;
+                } catch (NumberFormatException nfe) {
+                    return SESSION_TIMEOUT_INVALID_VALUE;
                 }
-                return SESSION_TIMEOUT_INVALID_VALUE;
             }
         });
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -635,7 +635,8 @@ Aucun fournisseur n\'a encore été ajouté</string>
 Ces formulaires avant de télécharger une version plus récente. </string>
     <string name="warning_logout_confirm">Etes-vous sûr de vouloir vous déconnectez et quitter Muzima app?</string>
     <string name="warning_registration_form_data_delete">Vous êtes sur le point de supprimer les données d\'enregistrement. Cela effacera également les données du client sur l\'appareil. Etes-vous sur?</string>
-    <string name="warning_session_timeout">Expiration de la session: Impossible de définir le délai d\'expiration de la session. La valeur donnée n\'est pas valide. </string>
+    <string name="warning_session_timeout">Expiration de la session: Impossible de définir le délai d\'expiration de la session.
+       Veuillez entrer une valeur entre 1 et 500. </string>
     <string name="warning_setting_download_failure">Echec du téléchargement ou de la mise à jour des configurations</string>
     <string name="warning_switch_server">Changement de serveur: Cela effacera toutes les données mUzima sur votre appareil, y compris les formulaires incomplets. Etes-vous sûr de vouloir modifier ce paramètre?</string>
     <string name="write_SHR_to_card_text">Ecrire SHR à la carte</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -696,7 +696,7 @@
         cliente no dispositivo. Tem certeza?
     </string>
     <string name="warning_session_timeout">Sessão expirou: não foi possível definir o tempo limite da sessão.
-        O valor fornecido é inválido.
+       Por favor insira um valor entre 1 e 500.
     </string>
     <string name="warning_setting_download_failure">Não foi possível baixar ou atualizar a configuração</string>
     <string name="warning_switch_server">Trocando o Servidor: Isto irá apagar todos dados de mUzima no seu dispositivo,

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -575,7 +575,8 @@
     <string formatted="false" name="warning_forms_complete_and_sync">%s ina fomu husika ndani yake. Tafadhali maliza kisha landanisha fomu hizo kabla ya kupakuwa toleo jipya kutoka kwenye Seva</string>
     <string name="warning_logout_confirm">Una uhakika unataka kutoka nje ya mfumo wa muzima?</string>
     <string name="warning_registration_form_data_delete">Kitendo hichi kitapelekea kufutwa kwa data za usajili hivyo basi rekodi ya mgojwa pia itafutwa kutoka kwenye kifaa hichi. Je una uhakika wa kuendelea? </string>
-    <string name="warning_session_timeout">Muda wa sesheni kuisha: Haikuweza kuweka muda wa kusitisha. Thamani iliyotolewa ni batili. </string>
+    <string name="warning_session_timeout">Muda wa sesheni kuisha: Haikuweza kuweka muda wa kusitisha.
+       Tafadhali ingiza thamani kati ya 1 na 500. </string>
     <string name="warning_setting_download_failure">Imeshindikana kupakua kisasisho cha utaratibu</string>
     <string name="warning_switch_server">Ubadilishaji wa seva: Kitendo hiki kitafuta data zote za mUzima katika kifaa chako, ikiwa ni pamoja na fomu zozote ambazo hazijakamilika bado. Una hakika unataka kubadili mpangilio huu?</string>
     <string name="write_SHR_to_card_text">Andika SHR kwa Kadi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -696,8 +696,8 @@
     <string name="warning_switch_server">Switching Server: This will clear all mUzima data on your
         device, including any incomplete forms. Are you sure you want to change this setting?
     </string>
-    <string name="warning_session_timeout">Session Timeout: Could not set session timeout. The
-        given value is invalid.
+    <string name="warning_session_timeout">Session Timeout: Could not set session timeout.
+        Please enter a value between 1 and 500.
     </string>
     <string name="write_SHR_to_card_text">Write SHR to Card</string>
     <string name="write_shr_to_card_general">Write SHR to card</string>


### PR DESCRIPTION
Hello, @benamonya, I made the modification. I use try-catch for the exception. I also updated the warning text on the alert dialog, so it informs the user about the valid values. (The dialog accepts numbers between 1 and 500) 