### PR TITLE
MUZIMA-687: change string concatenation for avoiding app crash

### DIFF
--- a/app/src/main/java/com/muzima/view/FeedbackActivity.java
+++ b/app/src/main/java/com/muzima/view/FeedbackActivity.java
@@ -55,10 +55,10 @@ public class FeedbackActivity extends BaseActivity {
             }
 
             private String composeMessage() {
-                String sender = String.join(" ", "Sender:", getUserName());
-                String rating = String.join(" ", "Rating:", String.valueOf(feedbackRatingBar.getRating()));
-                String feedback = String.join(" ", "Message:", feedbackText.getText().toString());
-                String message = String.join("\n", sender, rating, feedback);
+                String sender = "Sender: " + getUserName();
+                String rating = "Rating: " +  String.valueOf(feedbackRatingBar.getRating());
+                String feedback = "Message: " + feedbackText.getText().toString();
+                String message = sender + "\n" + rating+ "\n" + feedback;
                 return message;
             }
 


### PR DESCRIPTION
Hello @benamonya, I fixed the app crash problem was found on Friday during testing MUZIMA-688 ticket. The problem also affected MUZIMA-687. (It was caused by calling String.join method which is a Java 8 method). Please check my modification. Thanks.